### PR TITLE
Refactor concurrency

### DIFF
--- a/Mail/Views/Bottom sheets/Actions/ActionsViewModel.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsViewModel.swift
@@ -252,7 +252,7 @@ enum ActionsTarget: Equatable {
             } else if message.isDraft && message.uid.starts(with: Draft.uuidLocalPrefix) {
                 // Delete local draft from Realm
                 if let thread = message.parent {
-                    mailboxManager.deleteLocalDraft(thread: thread)
+                    await mailboxManager.deleteLocalDraft(thread: thread.freezeIfNeeded())
                 }
             } else {
                 // Move to trash

--- a/Mail/Views/New Message/NewMessageView.swift
+++ b/Mail/Views/New Message/NewMessageView.swift
@@ -318,7 +318,7 @@ struct NewMessageView: View {
         guard let draft = mailboxManager.draft(messageUid: messageUid, using: realm)?.freeze(),
               let draftFolder = mailboxManager.getFolder(with: .draft, using: realm) else { return }
         let thread = Thread(draft: draft)
-        try? realm.safeWrite {
+        try? realm.uncheckedSafeWrite {
             realm.add(thread, update: .modified)
             draftFolder.threads.insert(thread)
         }

--- a/Mail/Views/Search/SearchViewModel.swift
+++ b/Mail/Views/Search/SearchViewModel.swift
@@ -241,7 +241,7 @@ enum SearchFieldValueType: String {
             resourceNext = result.resourceNext
 
             if !searchValue.isEmpty {
-                searchHistory = mailboxManager.update(searchHistory: searchHistory, with: searchValue)
+                searchHistory = await mailboxManager.update(searchHistory: searchHistory, with: searchValue)
             }
             searchInfo.isLoading = false
             searchInfo.hasSearched = true

--- a/Mail/Views/Search/SearchViewModel.swift
+++ b/Mail/Views/Search/SearchViewModel.swift
@@ -116,12 +116,14 @@ enum SearchFieldValueType: String {
     }
 
     func clearSearchValue() {
-        searchFolder = mailboxManager.cleanSearchFolder()
-        searchValue = ""
-        threads = []
-        contacts = []
-        searchInfo.isLoading = false
-        searchInfo.hasSearched = false
+        Task {
+            searchFolder = await mailboxManager.cleanSearchFolder()
+            searchValue = ""
+            threads = []
+            contacts = []
+            searchInfo.isLoading = false
+            searchInfo.hasSearched = false
+        }
     }
 
     private var searchFilters: [URLQueryItem] {
@@ -216,7 +218,7 @@ enum SearchFieldValueType: String {
             return
         }
 
-        searchFolder = mailboxManager.cleanSearchFolder()
+        searchFolder = await mailboxManager.cleanSearchFolder()
         observeSearch = true
 
         searchInfo.isLoading = true

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -85,7 +85,7 @@ struct ThreadListView: View {
             ZStack {
                 MailResourcesAsset.backgroundColor.swiftUiColor
 
-                if $viewModel.sections.isEmpty && !viewModel.isLoadingPage {
+                if viewModel.folder?.lastUpdate != nil && viewModel.sections.isEmpty && !viewModel.isLoadingPage {
                     EmptyListView()
                 }
 

--- a/Mail/Views/Thread List/ThreadListViewModel.swift
+++ b/Mail/Views/Thread List/ThreadListViewModel.swift
@@ -158,7 +158,7 @@ class DateSection: Identifiable {
             resourceNext = result.resourceNext
         }
         isLoadingPage = false
-        mailboxManager.draftOffline()
+        await mailboxManager.draftOffline()
     }
 
     func fetchNextPage() async {
@@ -174,7 +174,7 @@ class DateSection: Identifiable {
             resourceNext = result.resourceNext
         }
         isLoadingPage = false
-        mailboxManager.draftOffline()
+        await mailboxManager.draftOffline()
     }
 
     func updateThreads(with folder: Folder) {

--- a/MailCore/Cache/BackgroundRealm.swift
+++ b/MailCore/Cache/BackgroundRealm.swift
@@ -39,16 +39,14 @@ public class BackgroundRealm {
         }
     }
 
-    public func execute(_ block: (Realm) -> Void) {
-        queue.sync {
-            block(realm)
-        }
+    public func execute<T>(_ block: (Realm) -> T) -> T {
+        return queue.sync { block(realm) }
     }
 
-    public func execute(_ block: (Realm) -> Void) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            execute(block)
-            continuation.resume()
+    public func execute<T>(_ block: (Realm) -> T) async -> T {
+        return await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
+            let result = execute(block)
+            continuation.resume(returning: result)
         }
     }
 }

--- a/MailCore/Cache/BackgroundRealm.swift
+++ b/MailCore/Cache/BackgroundRealm.swift
@@ -1,0 +1,54 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import RealmSwift
+
+public class BackgroundRealm {
+    private var realm: Realm!
+    private let queue: DispatchQueue
+
+    init(configuration: Realm.Configuration) {
+        guard let fileURL = configuration.fileURL else {
+            fatalError("Realm configurations without file URL not supported")
+        }
+        queue = DispatchQueue(label: "com.infomaniak.mail.\(fileURL.lastPathComponent)", autoreleaseFrequency: .workItem)
+
+        queue.sync {
+            do {
+                realm = try Realm(configuration: configuration, queue: queue)
+            } catch {
+                // We can't recover from this error but at least we report it correctly on Sentry
+                Logging.reportRealmOpeningError(error, realmConfiguration: configuration)
+            }
+        }
+    }
+
+    public func execute(_ block: (Realm) -> Void) {
+        queue.sync {
+            block(realm)
+        }
+    }
+
+    public func execute(_ block: (Realm) -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            execute(block)
+            continuation.resume()
+        }
+    }
+}

--- a/MailCore/Cache/ContactManager.swift
+++ b/MailCore/Cache/ContactManager.swift
@@ -86,7 +86,7 @@ public class ContactManager: ObservableObject {
 
             let realm = getRealm()
 
-            try? realm.safeWrite {
+            try? realm.uncheckedSafeWrite {
                 realm.add(addressBooks, update: .modified)
                 realm.add(contacts, update: .modified)
             }
@@ -157,7 +157,7 @@ public class ContactManager: ObservableObject {
 
         guard let newContact = contacts.first(where: { $0.id == String(contactId) }) else { throw MailError.contactNotFound }
         let realm = getRealm()
-        try? realm.safeWrite {
+        try? realm.uncheckedSafeWrite {
             realm.add(newContact)
         }
         if let mergedContact = mergedContacts[recipient.email] {

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -1093,7 +1093,7 @@ public extension Realm {
     }
 
     func safeWrite(_ block: () throws -> Void) throws {
-        assert(Foundation.Thread.isMainThread == false, "Writing on Main Thread is prohibited")
+        assert(!Foundation.Thread.isMainThread, "Writing on Main Thread is prohibited")
         if isInWriteTransaction {
             try block()
         } else {

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -60,9 +60,10 @@ public class MailboxManager: ObservableObject {
 
     public static let constants = MailboxManagerConstants()
 
-    public var realmConfiguration: Realm.Configuration
-    public var mailbox: Mailbox
+    public let realmConfiguration: Realm.Configuration
+    public let mailbox: Mailbox
     public private(set) var apiFetcher: MailApiFetcher
+    private let backgroundRealm: BackgroundRealm
 
     public init(mailbox: Mailbox, apiFetcher: MailApiFetcher) {
         self.mailbox = mailbox
@@ -86,6 +87,7 @@ public class MailboxManager: ObservableObject {
                 SearchHistory.self
             ]
         )
+        backgroundRealm = BackgroundRealm(configuration: realmConfiguration)
     }
 
     public func getRealm() -> Realm {

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -150,7 +150,7 @@ public class MailboxManager: ObservableObject {
 
         await backgroundRealm.execute { realm in
             for folder in newFolders {
-                keepCacheAttributes(for: folder, using: realm)
+                self.keepCacheAttributes(for: folder, using: realm)
             }
 
             let cachedFolders = realm.objects(Folder.self)
@@ -256,7 +256,7 @@ public class MailboxManager: ObservableObject {
 
             for thread in fetchedThreads {
                 for message in thread.messages {
-                    keepCacheAttributes(for: message, keepProperties: .standard, using: realm)
+                    self.keepCacheAttributes(for: message, keepProperties: .standard, using: realm)
                 }
             }
 
@@ -280,14 +280,14 @@ public class MailboxManager: ObservableObject {
             _ = try await apiFetcher.markAsSeen(mailbox: mailbox, messages: threads.flatMap(\.messages))
             await backgroundRealm.execute { realm in
                 for thread in threads {
-                    markAsSeen(thread: thread, using: realm)
+                    self.markAsSeen(thread: thread, using: realm)
                 }
             }
         } else {
             _ = try await apiFetcher.markAsUnseen(mailbox: mailbox, messages: threads.flatMap(\.messages))
             await backgroundRealm.execute { realm in
                 for thread in threads {
-                    markAsUnseen(thread: thread, using: realm)
+                    self.markAsUnseen(thread: thread, using: realm)
                 }
             }
         }
@@ -297,12 +297,12 @@ public class MailboxManager: ObservableObject {
         if thread.hasUnseenMessages {
             _ = try await apiFetcher.markAsSeen(mailbox: mailbox, messages: Array(thread.messages))
             await backgroundRealm.execute { realm in
-                markAsSeen(thread: thread, using: realm)
+                self.markAsSeen(thread: thread, using: realm)
             }
         } else {
             _ = try await apiFetcher.markAsUnseen(mailbox: mailbox, messages: Array(thread.messages))
             await backgroundRealm.execute { realm in
-                markAsUnseen(thread: thread, using: realm)
+                self.markAsUnseen(thread: thread, using: realm)
             }
         }
     }
@@ -313,7 +313,7 @@ public class MailboxManager: ObservableObject {
             if let liveFolder = folder.fresh(using: realm) {
                 for thread in threads {
                     if let liveThread = thread.fresh(using: realm) {
-                        try? moveLocally(thread: liveThread, to: liveFolder, using: realm)
+                        try? self.moveLocally(thread: liveThread, to: liveFolder, using: realm)
                     }
                 }
             }
@@ -328,7 +328,7 @@ public class MailboxManager: ObservableObject {
         await backgroundRealm.execute { realm in
             if let liveFolder = folder.fresh(using: realm),
                let liveThread = thread.fresh(using: realm) {
-                try? moveLocally(thread: liveThread, to: liveFolder, using: realm)
+                try? self.moveLocally(thread: liveThread, to: liveFolder, using: realm)
             }
         }
 
@@ -438,10 +438,10 @@ public class MailboxManager: ObservableObject {
     public func reportSpam(threads: [Thread]) async throws -> UndoResponse {
         let response = try await apiFetcher.reportSpam(mailbox: mailbox, messages: threads.flatMap(\.messages))
         await backgroundRealm.execute { realm in
-            if let spamFolder = getFolder(with: .spam, using: realm) {
+            if let spamFolder = self.getFolder(with: .spam, using: realm) {
                 for thread in threads {
                     if let liveThread = thread.fresh(using: realm) {
-                        try? moveLocally(thread: liveThread, to: spamFolder, using: realm)
+                        try? self.moveLocally(thread: liveThread, to: spamFolder, using: realm)
                     }
                 }
             }
@@ -453,9 +453,9 @@ public class MailboxManager: ObservableObject {
     public func reportSpam(thread: Thread) async throws -> UndoResponse {
         let response = try await apiFetcher.reportSpam(mailbox: mailbox, messages: Array(thread.messages))
         await backgroundRealm.execute { realm in
-            if let spamFolder = getFolder(with: .spam, using: realm),
+            if let spamFolder = self.getFolder(with: .spam, using: realm),
                let liveThread = thread.fresh(using: realm) {
-                try? moveLocally(thread: liveThread, to: spamFolder, using: realm)
+                try? self.moveLocally(thread: liveThread, to: spamFolder, using: realm)
             }
         }
 
@@ -465,10 +465,10 @@ public class MailboxManager: ObservableObject {
     public func nonSpam(threads: [Thread]) async throws -> UndoResponse {
         let response = try await apiFetcher.nonSpam(mailbox: mailbox, messages: threads.flatMap(\.messages))
         await backgroundRealm.execute { realm in
-            if let inboxFolder = getFolder(with: .inbox, using: realm) {
+            if let inboxFolder = self.getFolder(with: .inbox, using: realm) {
                 for thread in threads {
                     if let liveThread = thread.fresh(using: realm) {
-                        try? moveLocally(thread: liveThread, to: inboxFolder, using: realm)
+                        try? self.moveLocally(thread: liveThread, to: inboxFolder, using: realm)
                     }
                 }
             }
@@ -480,9 +480,9 @@ public class MailboxManager: ObservableObject {
     public func nonSpam(thread: Thread) async throws -> UndoResponse {
         let response = try await apiFetcher.nonSpam(mailbox: mailbox, messages: Array(thread.messages))
         await backgroundRealm.execute { realm in
-            if let inboxFolder = getFolder(with: .inbox, using: realm),
+            if let inboxFolder = self.getFolder(with: .inbox, using: realm),
                let liveThread = thread.fresh(using: realm) {
-                try? moveLocally(thread: liveThread, to: inboxFolder, using: realm)
+                try? self.moveLocally(thread: liveThread, to: inboxFolder, using: realm)
             }
         }
 
@@ -494,14 +494,14 @@ public class MailboxManager: ObservableObject {
             _ = try await apiFetcher.star(mailbox: mailbox, messages: threads.flatMap(\.messages))
             await backgroundRealm.execute { realm in
                 for thread in threads {
-                    star(thread: thread, using: realm)
+                    self.star(thread: thread, using: realm)
                 }
             }
         } else {
             _ = try await apiFetcher.unstar(mailbox: mailbox, messages: threads.flatMap(\.messages))
             await backgroundRealm.execute { realm in
                 for thread in threads {
-                    unstar(thread: thread, using: realm)
+                    self.unstar(thread: thread, using: realm)
                 }
             }
         }
@@ -511,13 +511,13 @@ public class MailboxManager: ObservableObject {
         if thread.flagged {
             _ = try await apiFetcher.unstar(mailbox: mailbox, messages: Array(thread.messages))
             await backgroundRealm.execute { realm in
-                unstar(thread: thread, using: realm)
+                self.unstar(thread: thread, using: realm)
             }
         } else {
             guard let lastMessage = thread.messages.last else { return }
             _ = try await apiFetcher.star(mailbox: mailbox, messages: [lastMessage])
             await backgroundRealm.execute { realm in
-                star(thread: thread, using: realm)
+                self.star(thread: thread, using: realm)
             }
         }
     }
@@ -609,7 +609,7 @@ public class MailboxManager: ObservableObject {
                 }
                 return liveFolder.freeze()
             } else {
-                return initSearchFolder().freeze()
+                return self.initSearchFolder().freeze()
             }
         }
     }
@@ -755,7 +755,7 @@ public class MailboxManager: ObservableObject {
         await backgroundRealm.execute { realm in
             if let folder = folder.fresh(using: realm) {
                 let messages = messages.compactMap { $0.fresh(using: realm) }
-                try? moveLocally(messages: messages, to: folder, using: realm)
+                try? self.moveLocally(messages: messages, to: folder, using: realm)
             }
         }
 
@@ -793,8 +793,8 @@ public class MailboxManager: ObservableObject {
         let response = try await apiFetcher.reportSpam(mailbox: mailbox, messages: messages)
 
         await backgroundRealm.execute { realm in
-            if let spamFolder = getFolder(with: .spam, using: realm) {
-                try? moveLocally(messages: messages, to: spamFolder, using: realm)
+            if let spamFolder = self.getFolder(with: .spam, using: realm) {
+                try? self.moveLocally(messages: messages, to: spamFolder, using: realm)
             }
         }
 
@@ -805,8 +805,8 @@ public class MailboxManager: ObservableObject {
         let response = try await apiFetcher.nonSpam(mailbox: mailbox, messages: messages)
 
         await backgroundRealm.execute { realm in
-            if let inboxFolder = getFolder(with: .inbox, using: realm) {
-                try? moveLocally(messages: messages, to: inboxFolder, using: realm)
+            if let inboxFolder = self.getFolder(with: .inbox, using: realm) {
+                try? self.moveLocally(messages: messages, to: inboxFolder, using: realm)
             }
         }
 
@@ -969,7 +969,7 @@ public class MailboxManager: ObservableObject {
         // Delete from API
         try await apiFetcher.deleteDraft(from: message)
         await backgroundRealm.execute { realm in
-            if let draft = draft(messageUid: message.uid, using: realm) {
+            if let draft = self.draft(messageUid: message.uid, using: realm) {
                 // Delete draft in Realm
                 try? realm.safeWrite {
                     realm.delete(draft)
@@ -984,11 +984,11 @@ public class MailboxManager: ObservableObject {
 
             let offlineDraftThread = List<Thread>()
 
-            guard let folder = getFolder(with: .draft, using: realm) else { return }
+            guard let folder = self.getFolder(with: .draft, using: realm) else { return }
 
             for draft in draftOffline {
                 let thread = Thread(draft: draft)
-                let from = Recipient(email: mailbox.email, name: mailbox.emailIdn)
+                let from = Recipient(email: self.mailbox.email, name: self.mailbox.emailIdn)
                 thread.from.append(from)
                 offlineDraftThread.append(thread)
             }
@@ -1006,7 +1006,7 @@ public class MailboxManager: ObservableObject {
     public func deleteLocalDraft(thread: Thread) async {
         await backgroundRealm.execute { realm in
             if let message = thread.messages.first,
-               let draft = draft(messageUid: message.uid) {
+               let draft = self.draft(messageUid: message.uid) {
                 try? realm.safeWrite {
                     realm.delete(draft)
                 }
@@ -1059,9 +1059,8 @@ public class MailboxManager: ObservableObject {
 
     private func keepCacheAttributes(
         for folder: Folder,
-        using realm: Realm? = nil
+        using realm: Realm
     ) {
-        let realm = realm ?? getRealm()
         guard let savedFolder = realm.object(ofType: Folder.self, forPrimaryKey: folder._id) else { return }
         folder.lastUpdate = savedFolder.lastUpdate
     }

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -1093,7 +1093,6 @@ public extension Realm {
     }
 
     func safeWrite(_ block: () throws -> Void) throws {
-        assert(!Foundation.Thread.isMainThread, "Writing on Main Thread is prohibited")
         if isInWriteTransaction {
             try block()
         } else {

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -1093,6 +1093,10 @@ public extension Realm {
     }
 
     func safeWrite(_ block: () throws -> Void) throws {
+        #if DEBUG
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        #endif
+
         if isInWriteTransaction {
             try block()
         } else {

--- a/MailCore/Utils/Realm+Extensions.swift
+++ b/MailCore/Utils/Realm+Extensions.swift
@@ -1,0 +1,30 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import RealmSwift
+
+extension Object {
+    public func fresh(using realm: Realm) -> Self? {
+        if let primaryKey = objectSchema.primaryKeyProperty?.name,
+           let primaryKeyValue = value(forKey: primaryKey) {
+            return realm.object(ofType: Self.self, forPrimaryKey: primaryKeyValue)
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Ensure that writes are done in the background with async continuation.

Starting now, only use `realm.safeWrite` when writing outside the main thread.
