### PR TITLE
Fix: Hitboxes composeview

### DIFF
--- a/Mail/Components/RecipientAutocompletionCell.swift
+++ b/Mail/Components/RecipientAutocompletionCell.swift
@@ -37,6 +37,7 @@ struct RecipientAutocompletionCell: View {
                         .textStyle(.bodySecondary)
                 }
             }
+            Spacer()
         }
     }
 }

--- a/Mail/Components/RecipientField.swift
+++ b/Mail/Components/RecipientField.swift
@@ -44,8 +44,8 @@ struct RecipientField: View {
     @Binding var recipients: [Recipient]
     @Binding var autocompletion: [Recipient]
     @Binding var addRecipientHandler: ((Recipient) -> Void)?
-    @FocusState var focusedField: RecipientFieldType?
-    let type: RecipientFieldType
+    @FocusState var focusedField: ComposeViewFieldType?
+    let type: ComposeViewFieldType
 
     @State private var currentText = ""
 

--- a/Mail/Helpers/RichTextEditor.swift
+++ b/Mail/Helpers/RichTextEditor.swift
@@ -178,7 +178,6 @@ class MailEditorView: SQTextEditorView {
         _webView.translatesAutoresizingMaskIntoConstraints = false
         _webView.navigationDelegate = self
         _webView.allowsLinkPreview = false
-        _webView.setKeyboardRequiresUserInteraction(false)
         _webView.addInputAccessoryView(toolbar: self.toolbar)
         self.updateToolbarItems(style: .main)
         _webView.scrollView.keyboardDismissMode = .interactive

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -216,6 +216,9 @@ struct ComposeMessageView: View {
                 await DraftManager.shared.saveDraftLocally(draft: draft, mailboxManager: mailboxManager, action: .save)
             }
         }
+        .onAppear {
+            focusedField = .to
+        }
         .onDisappear {
             // TODO: - Compare message body to original body : guard draft.body != originalBody || !draft.uuid.isEmpty else { return }
 

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -24,7 +24,7 @@ import PhotosUI
 import RealmSwift
 import SwiftUI
 
-enum RecipientFieldType: Hashable {
+enum ComposeViewFieldType: Hashable {
     case to, cc, bcc
 
     var title: String {
@@ -53,7 +53,7 @@ struct ComposeMessageView: View {
     @State private var originalBody: String
     @State private var editor = RichTextEditorModel()
     @State private var showCc = false
-    @FocusState private var focusedRecipientField: RecipientFieldType?
+    @FocusState private var focusedField: ComposeViewFieldType?
     @State private var addRecipientHandler: ((Recipient) -> Void)?
     @State private var autocompletion: [Recipient] = []
     @State private var isShowingCamera = false
@@ -69,7 +69,7 @@ struct ComposeMessageView: View {
     private let sendDisabled: Bool
 
     private var shouldDisplayAutocompletion: Bool {
-        return !autocompletion.isEmpty && focusedRecipientField != nil
+        return !autocompletion.isEmpty && focusedField != nil
     }
 
     private init(mailboxManager: MailboxManager, draft: UnmanagedDraft) {
@@ -261,20 +261,21 @@ struct ComposeMessageView: View {
     }
 
     @ViewBuilder
-    private func recipientCell(type: RecipientFieldType) -> some View {
-        let shouldDisplayField = !shouldDisplayAutocompletion || focusedRecipientField == type
+    private func recipientCell(type: ComposeViewFieldType) -> some View {
+        let shouldDisplayField = !shouldDisplayAutocompletion || focusedField == type
         if shouldDisplayField {
-            NewMessageCell(title: type.title, showCc: type == .to ? $showCc : nil) {
+            NewMessageCell(title: type.title,
+                           showCc: type == .to ? $showCc : nil) {
                 RecipientField(recipients: binding(for: type),
                                autocompletion: $autocompletion,
                                addRecipientHandler: $addRecipientHandler,
-                               focusedField: _focusedRecipientField,
+                               focusedField: _focusedField,
                                type: type)
             }
         }
     }
 
-    private func binding(for type: RecipientFieldType) -> Binding<[Recipient]> {
+    private func binding(for type: ComposeViewFieldType) -> Binding<[Recipient]> {
         let binding: Binding<[Recipient]>
         switch type {
         case .to:

--- a/Mail/Views/New Message/NewMessageCell.swift
+++ b/Mail/Views/New Message/NewMessageCell.swift
@@ -31,15 +31,21 @@ extension VerticalAlignment {
 }
 
 struct NewMessageCell<Content>: View where Content: View {
-    let title: String
+    let type: ComposeViewFieldType
+    let focusedField: FocusState<ComposeViewFieldType?>?
     let showCc: Binding<Bool>?
     let isFirstCell: Bool
     let content: Content
 
     let verticalPadding: CGFloat = 12
 
-    init(title: String, showCc: Binding<Bool>? = nil, isFirstCell: Bool = false, @ViewBuilder _ content: () -> Content) {
-        self.title = title
+    init(type: ComposeViewFieldType,
+         focusedField: FocusState<ComposeViewFieldType?>? = nil,
+         showCc: Binding<Bool>? = nil,
+         isFirstCell: Bool = false,
+         @ViewBuilder _ content: () -> Content) {
+        self.type = type
+        self.focusedField = focusedField
         self.showCc = showCc
         self.isFirstCell = isFirstCell
         self.content = content()
@@ -47,7 +53,7 @@ struct NewMessageCell<Content>: View where Content: View {
 
     var body: some View {
         HStack(alignment: .newMessageCellAlignment) {
-            Text(title)
+            Text(type.title)
                 .textStyle(.bodySecondary)
 
             content
@@ -61,6 +67,9 @@ struct NewMessageCell<Content>: View where Content: View {
         .padding(.horizontal, 16)
         .padding(.top, isFirstCell ? 0 : verticalPadding)
         .padding(.bottom, verticalPadding)
+        .onTapGesture {
+            focusedField?.wrappedValue = type
+        }
 
         IKDivider()
             .padding(.horizontal, 8)
@@ -69,14 +78,15 @@ struct NewMessageCell<Content>: View where Content: View {
 
 struct RecipientCellView_Previews: PreviewProvider {
     static var previews: some View {
-        NewMessageCell(title: "To:", showCc: .constant(false)) {
+        NewMessageCell(type: .to,
+                       showCc: .constant(false)) {
             RecipientField(recipients: .constant([PreviewHelper.sampleRecipient1]),
                            autocompletion: .constant([]),
                            addRecipientHandler: .constant { _ in /* Preview */ },
                            focusedField: .init(),
                            type: .to)
         }
-        NewMessageCell(title: "Subject:") {
+        NewMessageCell(type: .subject) {
             TextField("", text: .constant(""))
         }
     }


### PR DESCRIPTION
Fix hit box areas:

- [x] Message Body
- [x] Recipient (to, cc, bcc)
- [x] Contact suggestion
- [x] Fix jumping on user submit from recipient field  

Select "to" field on appear

Fix #349 
Fix #342 
