### PR TITLE
fix: Update unread count value when updating folder

### DIFF
--- a/Mail/Views/Thread List/ThreadListHeader.swift
+++ b/Mail/Views/Thread List/ThreadListHeader.swift
@@ -73,6 +73,11 @@ struct ThreadListHeader: View {
         .onChange(of: lastUpdate) { newValue in
             lastUpdateText = formatLastUpdate(date: newValue)
         }
+        .onChange(of: unreadCount) { newValue in
+            if newValue == 0 {
+                unreadFilterOn = false
+            }
+        }
         .onReceive(timer) { _ in
             lastUpdateText = formatLastUpdate(date: lastUpdate)
         }


### PR DESCRIPTION
Unread count value wasn't updated when a message (from another folder) was added to a thread in the current folder or when an action was performed on a message from another folder in the current folder.