### PR TITLE
refactor: Custom alerts as fullscreen sheet

### DIFF
--- a/Mail/Views/AlertView.swift
+++ b/Mail/Views/AlertView.swift
@@ -91,6 +91,7 @@ struct CustomAlertItemModifier<Item, AlertContent>: ViewModifier where Item: Ide
 }
 
 private struct ClearFullScreenView: UIViewRepresentable {
+    private static let maxSearchDepth = 5
     private class BackgroundRemovalView: UIView {
         override func didMoveToWindow() {
             super.didMoveToWindow()
@@ -98,9 +99,7 @@ private struct ClearFullScreenView: UIViewRepresentable {
         }
 
         private func clearBackgroundSuperviews(view: UIView, level: Int = 0) {
-            guard level < 5 else {
-                return
-            }
+            guard level < maxSearchDepth else { return }
 
             if let superview = view.superview {
                 superview.backgroundColor = .clear

--- a/Mail/Views/AlertView.swift
+++ b/Mail/Views/AlertView.swift
@@ -60,9 +60,32 @@ struct CustomAlertModifier<AlertContent>: ViewModifier where AlertContent: View 
     }
 }
 
+struct CustomAlertItemModifier<Item, AlertContent>: ViewModifier where Item: Identifiable, AlertContent: View {
+    @Binding var item: Item?
+    let alertView: (Item) -> AlertContent
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                Group {
+                    if let item {
+                        AlertView {
+                            alertView(item)
+                        }
+                    }
+                }
+                .animation(.default, value: item?.id)
+            }
+    }
+}
+
 extension View {
     func customAlert<Content: View>(isPresented: Binding<Bool>, @ViewBuilder content: () -> Content) -> some View {
         modifier(CustomAlertModifier(isPresented: isPresented, alertView: content()))
+    }
+
+    func customAlert<Item, Content>(item: Binding<Item?>, @ViewBuilder content: @escaping (Item) -> Content) -> some View where Item: Identifiable, Content: View {
+        modifier(CustomAlertItemModifier(item: item, alertView: content))
     }
 }
 


### PR DESCRIPTION
Present alerts fullscreen anywhere.
Present alert from an object binding instead of a Bool.