### PR TITLE
fix(Body): Value and Type can be null

### DIFF
--- a/Mail/Views/Thread/MessageBodyView.swift
+++ b/Mail/Views/Thread/MessageBodyView.swift
@@ -29,7 +29,7 @@ struct MessageBodyView: View {
         VStack {
             if let body = message.body {
                 if body.type == "text/plain" {
-                    Text(body.value)
+                    Text(body.value ?? "")
                         .textStyle(.body)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 16)

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -383,8 +383,8 @@ public struct BodyResult: Codable {
 }
 
 public class Body: EmbeddedObject, Codable {
-    @Persisted public var value: String
-    @Persisted public var type: String
+    @Persisted public var value: String?
+    @Persisted public var type: String?
     @Persisted public var subBody: String?
 }
 

--- a/MailCore/Utils/Constants.swift
+++ b/MailCore/Utils/Constants.swift
@@ -120,7 +120,7 @@ public enum Constants {
         <div>\(MailResourcesStrings.Localizable.toTitle) \(to)<br></div>
         <div><br></div>
         <div><br></div>
-        \(message.body?.value.replacingOccurrences(of: "'", with: "’") ?? "")
+        \(message.body?.value?.replacingOccurrences(of: "'", with: "’") ?? "")
         </div>
         """
     }
@@ -134,7 +134,7 @@ public enum Constants {
         <div id=\"answerContentMessage\" class=\"ik_mail_quote\" >
         <div>\(headerText)</div>
         <blockquote class=\"ws-ng-quote\">
-        \(message.body?.value.replacingOccurrences(of: "'", with: "’") ?? "")
+        \(message.body?.value?.replacingOccurrences(of: "'", with: "’") ?? "")
         </blockquote>
         </div>
         """


### PR DESCRIPTION
- Write a message from Mail.app (macOS)
- Empty Body
- Add an attachment

-> Value and Type are null